### PR TITLE
Renamed constructor name

### DIFF
--- a/src/class.upload.php
+++ b/src/class.upload.php
@@ -2008,7 +2008,7 @@ class upload {
      *    or   string $file Local filename
      * @param  string $lang Optional language code
      */
-    function upload($file, $lang = 'en_GB') {
+    function __construct($file, $lang = 'en_GB') {
 
         $this->version            = '0.33dev';
 


### PR DESCRIPTION
PHP 4 style constructors are deprecated. PHP 7 will emit E_DEPRECATED if a PHP 4 constructor is the only constructor defined within a class. Classes that implement a __construct() method are unaffected.