### PR TITLE
change constuctor name

### DIFF
--- a/src/class.upload.php
+++ b/src/class.upload.php
@@ -2035,7 +2035,7 @@ class upload {
      *    or   string $file Local filename
      * @param  string $lang Optional language code
      */
-    function upload($file, $lang = 'en_GB') {
+    function __construct($file, $lang = 'en_GB') {
 
         $this->version            = '0.34dev';
 


### PR DESCRIPTION
`upload()` -> `__construct()`
PHP7 throws E_DEPRECATED error here: Methods with the same name as their class will not be constructors in a future version of PHP.