### PR TITLE
Chrome image/x-ms-bmp problem

### DIFF
--- a/src/class.upload.php
+++ b/src/class.upload.php
@@ -2530,6 +2530,11 @@ class upload {
                 $this->file_is_image = true;
                 $this->image_src_type = $this->image_supported[$this->file_src_mime];
             }
+            
+            if ($this->file_src_mime === "image/x-ms-bmp") {
+               $this->file_src_mime = "image/bmp";
+               $this->log .= 'New MIME type set to ' . $this->file_src_mime . ' for incopatibility with Chrome<br />';
+            }
 
             // if the file is an image, we gather some useful data
             if ($this->file_is_image) {


### PR DESCRIPTION
Chrome doesn't properly handle image/x-ms-bmp mime type
(see https://bugs.chromium.org/p/chromium/issues/detail?id=449489)

It's a quick fix, if you have something better do as you want.