### PR TITLE
mime_content_type(): Can only process string or stream arguments

### DIFF
--- a/src/class.upload.php
+++ b/src/class.upload.php
@@ -2213,7 +2213,7 @@ class Upload {
                 $this->uploaded = false;
                 $this->error = $this->translate('file_error');
             } else {
-		$file = (string) $file;
+                $file = (string) $file;
                 if (substr($file, 0, 4) == 'php:' || substr($file, 0, 5) == 'data:' || substr($file, 0, 7) == 'base64:') {
                     $data = null;
 

--- a/src/class.upload.php
+++ b/src/class.upload.php
@@ -2213,6 +2213,7 @@ class Upload {
                 $this->uploaded = false;
                 $this->error = $this->translate('file_error');
             } else {
+		$file = (string) $file;
                 if (substr($file, 0, 4) == 'php:' || substr($file, 0, 5) == 'data:' || substr($file, 0, 7) == 'base64:') {
                     $data = null;
 

--- a/src/class.upload.php
+++ b/src/class.upload.php
@@ -2316,7 +2316,7 @@ class Upload {
             // this is an element from $_FILE, i.e. an uploaded file
             $this->log .= '<b>source is an uploaded file</b><br />';
             if ($this->uploaded) {
-                $this->file_src_error         = trim($file['error']);
+                $this->file_src_error         = trim((int) $file['error']);
                 switch($this->file_src_error) {
                     case UPLOAD_ERR_OK:
                         // all is OK
@@ -2357,8 +2357,8 @@ class Upload {
             }
 
             if ($this->uploaded) {
-                $this->file_src_pathname   = $file['tmp_name'];
-                $this->file_src_name       = $file['name'];
+                $this->file_src_pathname   = (string) $file['tmp_name'];
+                $this->file_src_name       = (string) $file['name'];
                 if ($this->file_src_name == '') {
                     $this->uploaded = false;
                     $this->error = $this->translate('try_again');
@@ -2375,8 +2375,8 @@ class Upload {
                     $this->file_src_name_ext      = '';
                     $this->file_src_name_body     = $this->file_src_name;
                 }
-                $this->file_src_size = $file['size'];
-                $mime_from_browser = $file['type'];
+                $this->file_src_size = (int) $file['size'];
+                $mime_from_browser = (string) $file['type'];
             }
         }
 


### PR DESCRIPTION
sometimes , specially in laravel :
$this->file_src_pathname , in line 2484 class.upload.php , is not string and to use mime_content_type function , we should change that to string , because of that I change line 2484 to :

$this->file_src_mime = mime_content_type(strval($this->file_src_pathname));

and it's done