### PR TITLE
PHP 7.4 Support added

### DIFF
--- a/src/class.upload.php
+++ b/src/class.upload.php
@@ -2796,7 +2796,10 @@ class Upload {
      */
     function getsize($size) {
         if ($size === null) return null;
-        $last = strtolower($size{strlen($size)-1});
+        $last = '';
+        if (is_string($size)) {
+            $last = strtolower($size[strlen($size)-1]);
+        }
         $size = (int) $size;
         switch($last) {
             case 'g':


### PR DESCRIPTION
The new PHP version throws this warning "Trying to access array offset on value of type int". To prevent that simple string check added. Tested in PHP 7.3 and 7.4 works fine under Ubuntu 16.04LTS with Nginx+FPM